### PR TITLE
Extend derive of DeviceInfo and DevicePath types.

### DIFF
--- a/src/info.rs
+++ b/src/info.rs
@@ -8,7 +8,7 @@ use crate::path::DevicePath;
 
 /// Device information. Use accessors to extract information about connected devices.
 #[cfg_attr(feature = "bincode", derive(Decode, Encode))]
-#[derive(Debug)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct DeviceInfo {
     pub(crate) path: DevicePath,
 

--- a/src/path.rs
+++ b/src/path.rs
@@ -6,7 +6,7 @@ use bincode::{
 
 /// Device mount path.
 #[cfg_attr(feature = "bincode", derive(Decode, Encode))]
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum DevicePath {
     /// A PCI device path.
     PCI {


### PR DESCRIPTION
It is beneicial to have these traits implemented for types provided as part of public API. 
Especially if it comes with almost zero effort.